### PR TITLE
fix(config_flow): handle empty user_input and no-connectable-path

### DIFF
--- a/custom_components/hiflow_ble/config_flow.py
+++ b/custom_components/hiflow_ble/config_flow.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 
 from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
+    async_ble_device_from_address,
     async_discovered_service_info,
 )
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
@@ -86,24 +87,48 @@ class HiFlowBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         current_addresses = self._async_current_ids()
+        # Include non-connectable scanners so the picker isn't misleadingly
+        # empty when only passive proxies (e.g. Shelly Gen2) are in range.
+        # We validate connectability separately once the user has picked a
+        # device and can show a targeted error instead of hiding the device.
         seen: list[tuple[str, str]] = []
-        for info in async_discovered_service_info(self.hass):
+        for info in async_discovered_service_info(self.hass, connectable=False):
             if info.address in current_addresses:
                 continue
             if not derive_sn_from_local_name(info.name):
                 continue
             seen.append((info.address, info.name))
 
-        if user_input is not None:
+        if user_input is not None and CONF_ADDRESS in user_input:
             self._address = user_input[CONF_ADDRESS]
             for addr, name in seen:
                 if addr == self._address:
                     self._local_name = name
                     break
-            self._sn = derive_sn_from_local_name(self._local_name)
-            await self.async_set_unique_id(self._address)
-            self._abort_if_unique_id_configured()
-            return await self.async_step_pair()
+            # Require a connectable path to the selected device. BLE pairing
+            # needs a real GATT connection; passive-only scanners (Shelly
+            # Gen2, some ESPHome BLE proxies without `active: true`) can see
+            # the advert but cannot establish a link.
+            if (
+                async_ble_device_from_address(
+                    self.hass, self._address, connectable=True
+                )
+                is None
+            ):
+                _LOGGER.warning(
+                    "No connectable Bluetooth adapter/proxy can reach %s (%s). "
+                    "Add an ESPHome BLE proxy with `bluetooth_proxy: active: true` "
+                    "in range of the inverter, or attach a USB BLE dongle to the "
+                    "Home Assistant host.",
+                    self._local_name or self._address,
+                    self._address,
+                )
+                errors["base"] = "not_connectable"
+            else:
+                self._sn = derive_sn_from_local_name(self._local_name)
+                await self.async_set_unique_id(self._address)
+                self._abort_if_unique_id_configured()
+                return await self.async_step_pair()
 
         if not seen:
             return self.async_show_form(step_id="user", errors={"base": "no_devices"})

--- a/custom_components/hiflow_ble/strings.json
+++ b/custom_components/hiflow_ble/strings.json
@@ -37,7 +37,8 @@
     "error": {
       "cannot_connect": "Bluetooth connection failed. Is the inverter in range?",
       "pairing_failed": "Pairing handshake failed. Close the S-Miles app and try again.",
-      "no_devices": "No HiFlow devices discovered. Make sure Bluetooth is enabled and the inverter is in range."
+      "no_devices": "No HiFlow devices discovered. Make sure Bluetooth is enabled and the inverter is in range.",
+      "not_connectable": "This device is only visible via passive proxies (e.g. Shelly Gen2). Pairing requires an ACTIVE, connectable proxy: use an ESPHome BLE proxy with `bluetooth_proxy: active: true` in range of the inverter, or attach a USB BLE dongle to the Home Assistant host."
     },
     "abort": {
       "already_configured": "Already configured.",

--- a/custom_components/hiflow_ble/translations/de.json
+++ b/custom_components/hiflow_ble/translations/de.json
@@ -37,7 +37,8 @@
     "error": {
       "cannot_connect": "Bluetooth-Verbindung fehlgeschlagen. Ist der Wechselrichter in Reichweite?",
       "pairing_failed": "Pairing-Handshake fehlgeschlagen. Schließe die S-Miles-App und versuche es erneut.",
-      "no_devices": "Keine HiFlow-Geräte gefunden. Ist Bluetooth aktiviert und der Wechselrichter in Reichweite?"
+      "no_devices": "Keine HiFlow-Geräte gefunden. Ist Bluetooth aktiviert und der Wechselrichter in Reichweite?",
+      "not_connectable": "Dieses Gerät ist nur über passive Proxys sichtbar (z. B. Shelly Gen2). Für das Pairing wird ein AKTIVER, verbindungsfähiger Proxy benötigt: ESPHome-BLE-Proxy mit `bluetooth_proxy: active: true` in Reichweite des Wechselrichters, oder ein USB-BLE-Stick am Home-Assistant-Host."
     },
     "abort": {
       "already_configured": "Bereits konfiguriert.",

--- a/custom_components/hiflow_ble/translations/en.json
+++ b/custom_components/hiflow_ble/translations/en.json
@@ -37,7 +37,8 @@
     "error": {
       "cannot_connect": "Bluetooth connection failed. Is the inverter in range?",
       "pairing_failed": "Pairing handshake failed. Close the S-Miles app and try again.",
-      "no_devices": "No HiFlow devices discovered. Make sure Bluetooth is enabled and the inverter is in range."
+      "no_devices": "No HiFlow devices discovered. Make sure Bluetooth is enabled and the inverter is in range.",
+      "not_connectable": "This device is only visible via passive proxies (e.g. Shelly Gen2). Pairing requires an ACTIVE, connectable proxy: use an ESPHome BLE proxy with `bluetooth_proxy: active: true` in range of the inverter, or attach a USB BLE dongle to the Home Assistant host."
     },
     "abort": {
       "already_configured": "Already configured.",


### PR DESCRIPTION
## Summary

Fix two related bugs in `config_flow.py` that both surface at the "pick an RMI-* device" step, both currently indistinguishable from each other in the UI (they both show as "Unknown error occurred" or a silently empty picker).

### 1. `KeyError` on empty `user_input`

Home Assistant may invoke `async_step_user` with an empty dict (for example when the flow was triggered via a discovery/adoption path) rather than `None`. The existing `if user_input is not None:` guard let that empty dict fall through to `user_input[CONF_ADDRESS]`, raising `KeyError` and bubbling up as **"Unknown error occurred"** in the UI.

Fix: tighten the guard to `if user_input is not None and CONF_ADDRESS in user_input:` so the flow re-renders the picker instead of crashing.

Traceback observed:
```
File "/config/custom_components/hiflow_ble/config_flow.py", line 107, in async_step_user
    self._address = user_input[CONF_ADDRESS]
                    ~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'address'
```

### 2. Silently hidden devices when no connectable proxy is in range

`async_discovered_service_info` defaults to `connectable=True`, which filters out devices only visible via passive scanners. In practice this hides RMI-* devices even when they're being clearly advertised, because the most common BLE proxies people already own are passive-only:

- **Shelly Gen2 BLE gateways are always registered as non-connectable** by HA, [by design in `aioshelly`](https://github.com/home-assistant-libs/aioshelly/blob/main/aioshelly/ble/__init__.py) — the `HaBluetoothConnector` is built with `can_connect=lambda: False` and the comment "no active connections to shelly yet". This is true even when the Shelly is configured for "active" scan mode.
- ESPHome BLE proxies without `bluetooth_proxy: active: true` are also passive-only.

Result: the device picker appears empty, or is missing the RMI, with no explanation. Users have no idea whether their inverter is even being seen.

Fix:
1. Change the discovery call to `connectable=False` so the picker lists every RMI-* device the BLE mesh can see, connectable or not.
2. Add a pre-flight check after the user picks a device: if `async_ble_device_from_address(..., connectable=True)` returns `None`, log a warning and re-render the form with a new `not_connectable` error that points users at the actual fix (add an active ESPHome BLE proxy in range, or attach a local USB BLE dongle) — instead of proceeding to a pair attempt that will fail 15s later with a generic BLE error.

The new error string is added to `strings.json`, `translations/en.json`, and `translations/de.json` (matching the existing language coverage).

## How this was reproduced

Setup: HAOS 2026.7.4, HMS-2000-4WB (`RMI-4162A031D1C8`), only Shelly Gen2 devices as BLE proxies (all `connectable=false`).

- Before this PR: clicking **+ Add integration → HiFlow BLE** either crashed with "Unknown error occurred" (when HA triggered a discovery-driven flow with empty `user_input`) or showed an empty picker (because all scanners in range were passive).
- After this PR: the picker lists the RMI, and selecting it shows the new `not_connectable` message with a clear next step.

Once the user adds a connectable proxy (in my case an Olimex ESP32-POE with `bluetooth_proxy: active: true`), the picker → pair flow completes normally.

## Notes for reviewers

- No behavior change for users who already have a working connectable proxy — they still fall straight through to `async_step_pair`.
- The `not_connectable` branch falls through to the picker re-render at the bottom of the function (via `errors["base"]`) instead of duplicating the `async_show_form` call, matching how the existing `errors` flow already works.
- I only touched the manual `user` step; the auto-triggered `bluetooth` step is unaffected because HA only routes to it via connectable scanners in the first place.

## Out of scope but related

While debugging this I also hit a separate issue: the bundled `hiflow-ble` library ships protobuf `_pb2` files compiled with `protoc 6.31.1` but declares `protobuf>=5.29.3` — the gencode/runtime major-version mismatch raises `VersionError` at import time on HA (which ships protobuf 5.x), also surfacing as "Unknown error occurred". That's a bug in the `hiflow-ble` library, not in this integration, so I'll file it separately at TheTiEr/hiflow-ble — the proper fix is to regenerate the `_pb2` files with `protoc` 5.x (matching the declared dependency) or bump the declared dependency to `protobuf>=6.30`.
