### PR TITLE
fix: skip reconnect when no connectable BLEDevice is available

### DIFF
--- a/custom_components/hiflow_ble/coordinator.py
+++ b/custom_components/hiflow_ble/coordinator.py
@@ -108,15 +108,16 @@ class HiFlowDataUpdateCoordinator(DataUpdateCoordinator):
                 self._config_entry.data[CONF_ADDRESS],
                 connectable=True,
             )
-            if fresh is not None:
-                self._hiflow.address = fresh
-            else:
-                _LOGGER.debug(
-                    "HiFlow: no connectable BLEDevice found for %s — "
-                    "reconnect will use cached address (bleak_retry_connector "
-                    "path unavailable until device re-advertises)",
-                    self._config_entry.data.get(CONF_ADDRESS, "?"),
-                )
+            if fresh is None:
+                # The library only takes the bleak_retry_connector path for a
+                # BLEDevice; with the cached string address it falls back to a
+                # plain BleakClient.connect().  That bypasses the retry logic
+                # and re-hammers the proxy on every poll for as long as the
+                # device stays invisible.  Nothing is reachable anyway, so wait
+                # for the next advertisement instead.
+                self._on_unreachable("not advertising to any connectable adapter")
+                return False
+            self._hiflow.address = fresh
             try:
                 await self._hiflow._ensure_connected()  # serialised by _connect_lock
             except BleLinkError as err:


### PR DESCRIPTION
Hi! Thanks for the integration - I was glad to discover that there is another way to get the inverter data locally even though the wifi-based integration does not work for the hiflow devices.

While going through logs in HA i saw lots of warnings though due to missing usage of `bleak_retry_connector`, this is my attempt to fix it.

## Problem

`hiflow_ble.hiflow.connect()` only takes the `bleak_retry_connector` path when `self.address` is a `BLEDevice`:

```python
if isinstance(self.address, BLEDevice):
    _connected = await _ec(BleakClient, self.address, name, ...)
...
if _connected is None:
    _plain = BleakClient(self.address, disconnected_callback=self._on_disconnect)
    await _plain.connect(timeout=self.timeout * 2)
```

`async_setup_entry` constructs `HiFlow` with the plain address string when no connectable `BLEDevice` is visible at HA startup (`__init__.py`: `target = ble_device if ble_device is not None else address`). `_ensure_connected` then refreshed the `BLEDevice` on every reconnect, but tolerated a `None` result, logged it at DEBUG and reconnected anyway. As long as the device had never been seen since startup, `self.address` stayed a string and the library silently dropped to the plain `BleakClient.connect()` fallback — no retry logic, no backoff, once per 30s poll for as long as the device stayed invisible.

(If the device *had* been seen once, the cached value is a stale `BLEDevice` and the old code still went through `establish_connection`; the storm is specific to the startup-while-invisible case.)

On my instance that produced **2373** `habluetooth.wrappers` warnings

```
80:9D:65:24:D9:5C: BleakClient.connect() called without bleak-retry-connector.
For reliable connection establishment, use bleak_retry_connector.establish_connection().
```

in ~30h, all from one stretch where the inverter was not reachable by any proxy after an HA restart.

The feedback loop is the nasty part: the connect storm loads exactly the ESPHome BLE proxies whose missed advertisements made the device invisible to begin with.

## Fix

If no adapter can currently see the device there is nothing to connect to. Bail out via the existing `_on_unreachable` path and let `DataUpdateCoordinator` retry on the next interval — same shape as the `BleLinkError` branch a few lines below, and the same pattern core BLE integrations use (`async_ble_device_from_address` → `None` → `UpdateFailed`).

Net effect: the coordinator never asks the library to connect with a string address, so the polling loop can no longer reach the plain-connect fallback.
