### PR TITLE
fix: send Home Assistant's timezone to the inverter, not a fixed CET

### DIFF
--- a/custom_components/hiflow_ble/coordinator.py
+++ b/custom_components/hiflow_ble/coordinator.py
@@ -32,7 +32,7 @@ from hiflow_ble.errors import BleLinkError, EncRandStale
 from hiflow_ble.hiflow import HiFlow
 
 from .const import CONF_ADDRESS, DOMAIN
-from .util import async_check_and_update_enc_rand
+from .util import async_check_and_update_enc_rand, current_tz_offset_seconds
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -133,7 +133,9 @@ class HiFlowDataUpdateCoordinator(DataUpdateCoordinator):
         if not self._hiflow._handshake_done:
             ok = False
             try:
-                ok = await self._hiflow.async_do_comm_cmd_handshake()
+                ok = await self._hiflow.async_do_comm_cmd_handshake(
+                    tz_offset=current_tz_offset_seconds()
+                )
             except Exception as err:
                 _LOGGER.warning("CommCmd handshake raised: %s", err)
             if not ok:
@@ -148,7 +150,9 @@ class HiFlowDataUpdateCoordinator(DataUpdateCoordinator):
                     await async_check_and_update_enc_rand(
                         self.hass, self._config_entry, self._hiflow, new_key.hex()
                     )
-                    ok = await self._hiflow.async_do_comm_cmd_handshake()
+                    ok = await self._hiflow.async_do_comm_cmd_handshake(
+                        tz_offset=current_tz_offset_seconds()
+                    )
                     if ok:
                         _LOGGER.warning("V0 re-pair succeeded — encRand refreshed")
                     else:

--- a/custom_components/hiflow_ble/util.py
+++ b/custom_components/hiflow_ble/util.py
@@ -9,6 +9,7 @@ from typing import Any
 from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from hiflow_ble.hiflow import HiFlow, generate_ble_id
 from hiflow_ble.hoymiles import generate_inverter_serial_number
@@ -25,6 +26,17 @@ from .const import (
 from .error import CannotConnect, PairingFailed
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def current_tz_offset_seconds() -> int:
+    """Return Home Assistant's configured UTC offset in seconds.
+
+    Read on every call so a daylight-saving transition is picked up without a
+    restart, and taken from HA's own timezone rather than the host's — the two
+    can differ, and the inverter should follow the one the user configured.
+    """
+    offset = dt_util.now().utcoffset()
+    return int(offset.total_seconds()) if offset is not None else 0
 
 
 def detect_rated_power_w(config_entry: ConfigEntry) -> int:
@@ -127,7 +139,9 @@ async def async_pair_and_probe(
 
         # CommCmd handshake: login (action=64) + optional PIN (action=82) + time-sync (action=104).
         # The device won't answer V1 RealData requests until this succeeds.
-        ok = await hiflow.async_do_comm_cmd_handshake(ble_id=ble_id, pin=pin)
+        ok = await hiflow.async_do_comm_cmd_handshake(
+            ble_id=ble_id, pin=pin, tz_offset=current_tz_offset_seconds()
+        )
         if not ok:
             _LOGGER.warning(
                 "CommCmd handshake failed for %s — bleId not accepted. "


### PR DESCRIPTION
## Problem

`async_do_comm_cmd_handshake()` is called without `tz_offset`, so it falls back
to the library's hard-coded `OFFSET = 3600` (CET). Throughout CEST that sets the
inverter's clock an hour behind; outside central Europe it is wrong all year.

On my install the S-Miles cloud reported the inverter "offline" every morning at
08:00 while it was producing normally — its own timestamps looked an hour stale.
The reports stopped after I fixed the offset and have not returned in nine
mornings.

## Change

`current_tz_offset_seconds()` reads **Home Assistant's** configured timezone via
`dt_util.now().utcoffset()` and passes it to all three handshake call sites (the
first-pairing handshake in `util.py`, and both in the coordinator).

It is read per handshake rather than cached, so a DST transition is picked up
without a restart. Taking it from HA rather than the host matters because the
two can differ, and the inverter should follow what the user configured in HA.

## Scope

This uses the `tz_offset` parameter `async_do_comm_cmd_handshake` already
accepts, so **it needs no new library version** and can go in on its own.

It fixes the action=104 time-sync only. `request.offset` on the individual
requests still uses the library constant; that is fixed in
TheTiEr/hiflow-ble#4. Once that is released, passing `tz_offset` to the `HiFlow(…)`
constructor here would cover both paths in one place — happy to send that as a
follow-up after the library release.

Refs #18.
