### PR TITLE
fix: reload only when options actually changed

### DIFF
--- a/custom_components/hiflow_ble/__init__.py
+++ b/custom_components/hiflow_ble/__init__.py
@@ -29,6 +29,7 @@ from .const import (
     HASS_DATA_COORDINATOR,
     HASS_HEARTBEAT_COORDINATOR,
     HASS_HIFLOW,
+    HASS_OPTIONS_SNAPSHOT,
 )
 from .coordinator import (
     HiFlowConfigUpdateCoordinator,
@@ -97,6 +98,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         HASS_DATA_COORDINATOR: data_coordinator,
         HASS_CONFIG_COORDINATOR: config_coordinator,
         HASS_HEARTBEAT_COORDINATOR: heartbeat_coordinator,
+        HASS_OPTIONS_SNAPSHOT: dict(entry.options),
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -126,7 +128,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def _async_reload_on_options_change(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> None:
-    """Reload the config entry so new options (e.g. polling interval) take effect."""
+    """Reload the config entry when the user saved new options.
+
+    Home Assistant runs update listeners on *every* config-entry change, not
+    just option changes. This integration rewrites ``entry.data`` whenever the
+    device hands out a fresh ``encRand`` during a V0 re-pair, so an unguarded
+    reload here turns each key rotation into a full teardown and setup while
+    the in-memory client already holds the new key.
+
+    Comparing against the snapshot taken at setup keeps reloads to actual
+    option changes.
+    """
+    stash = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if stash is not None and stash.get(HASS_OPTIONS_SNAPSHOT) == dict(entry.options):
+        _LOGGER.debug("Config entry data changed, options unchanged — no reload")
+        return
     await hass.config_entries.async_reload(entry.entry_id)
 
 

--- a/custom_components/hiflow_ble/const.py
+++ b/custom_components/hiflow_ble/const.py
@@ -56,3 +56,7 @@ HASS_DATA_COORDINATOR = "data_coordinator"
 HASS_CONFIG_COORDINATOR = "config_coordinator"
 HASS_HEARTBEAT_COORDINATOR = "heartbeat_coordinator"
 HASS_HIFLOW = "hiflow"
+# Snapshot of entry.options taken at setup. The update listener compares
+# against it so that writes to entry.data (the rotating encRand) do not
+# trigger a reload — see _async_reload_on_options_change.
+HASS_OPTIONS_SNAPSHOT = "options_snapshot"


### PR DESCRIPTION
## Problem

Home Assistant runs update listeners on **every** config-entry change, not just
option changes. `_async_reload_on_options_change` reloads unconditionally.

This integration writes to `entry.data` on its own: every V0 re-pair persists a
fresh `encRand` via `async_check_and_update_enc_rand` → `async_update_entry`.
Each key rotation therefore triggered a full teardown and setup, even though the
in-memory client already holds the new key and nothing needs re-reading.

It compounds in the morning. When the inverter wakes up, the handshake fails
until the BLE link settles; each attempt re-pairs and rotates the key, and the
reloads pile up — about twelve within ten minutes on my four-port unit, tearing
down and rebuilding 43 entities each time. In the recorder that shows up as
0.1 s `unavailable → 0.0` flips across every sensor, which is indistinguishable
from a real dropout when you are reading history.

## Change

The entry keeps a snapshot of `entry.options` in its `hass.data` slot and the
listener reloads only when the current options differ from it. Writes to
`entry.data` are ignored. The snapshot is refreshed by setup itself, so an
actual option change reloads once and re-snapshots.

No behaviour change for the case the listener was registered for: saving new
options in the UI still reloads.

Closes #19.
